### PR TITLE
Generate url_key with Magento's translit filter so non-Latin target languages work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Automatic Translation
+## [2.3.0] - 26/08/2026
+### Added
+- Support for non-Latin target languages (e.g. Greek, Cyrillic): product and category URL keys are now transliterated with Magento's URL translit filter, the same one core uses to generate URL keys
+### Fixed
+- Translating a product or category into a store view with a non-Latin alphabet no longer fails on save with an invalid URL key error caused by every non-Latin character being stripped down to a single dash
 ## [2.2.1] - 13/07/2026
 ### Fixed
 - Fixed a null argument error when creating a product under PHP 8.5

--- a/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace MageOS\AutomaticTranslation\Plugin;
 
 use Magento\Catalog\Controller\Adminhtml\Category\Save;
+
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Filter\FilterManager;
 use MageOS\AutomaticTranslation\Helper\ModuleConfig;
 use MageOS\AutomaticTranslation\Helper\Service;
 use MageOS\AutomaticTranslation\Service\TranslateParsedContent;
@@ -35,7 +37,8 @@ class AdminhtmlCategoryBeforeSavePlugin
         protected Service $serviceHelper,
         protected ManagerInterface $messageManager,
         protected Logger $logger,
-        protected TranslateParsedContent $translateParsedContent
+        protected TranslateParsedContent $translateParsedContent,
+        protected FilterManager $filterManager
     ) {
     }
 
@@ -73,8 +76,8 @@ class AdminhtmlCategoryBeforeSavePlugin
                     );
 
                     if ($attributeCode === 'url_key') {
-                        $requestPostValue[$attributeCode] = strtolower(
-                            (string)preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue[$attributeCode])
+                        $requestPostValue[$attributeCode] = $this->filterManager->translitUrl(
+                            (string)$requestPostValue[$attributeCode]
                         );
                     }
 

--- a/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MageOS\AutomaticTranslation\Plugin;
 
 use Magento\Catalog\Controller\Adminhtml\Category\Save;
-
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Filter\FilterManager;
 use MageOS\AutomaticTranslation\Helper\ModuleConfig;

--- a/Plugin/AdminhtmlProductBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlProductBeforeSavePlugin.php
@@ -6,6 +6,7 @@ namespace MageOS\AutomaticTranslation\Plugin;
 
 use Magento\Catalog\Controller\Adminhtml\Product\Save;
 use Magento\Catalog\Model\ResourceModel\Product\Gallery;
+use Magento\Framework\Filter\FilterManager;
 use Magento\Framework\Message\ManagerInterface;
 use MageOS\AutomaticTranslation\Helper\ModuleConfig;
 use MageOS\AutomaticTranslation\Helper\Service;
@@ -33,7 +34,8 @@ class AdminhtmlProductBeforeSavePlugin
         protected Gallery $gallery,
         protected ManagerInterface $messageManager,
         protected Logger $logger,
-        protected TranslateParsedContent $translateParsedContent
+        protected TranslateParsedContent $translateParsedContent,
+        protected FilterManager $filterManager
     ) {
     }
 
@@ -88,8 +90,8 @@ class AdminhtmlProductBeforeSavePlugin
                 );
 
                 if ($attributeCode === 'url_key') {
-                    $requestPostValue["product"][$attributeCode] = strtolower(
-                        (string)preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue["product"][$attributeCode])
+                    $requestPostValue["product"][$attributeCode] = $this->filterManager->translitUrl(
+                        $requestPostValue["product"][$attributeCode]
                     );
                 }
 


### PR DESCRIPTION
## Problem

When the target store view uses a non-Latin script (Greek, Cyrillic, …), translating a category or product fails on save with:

> Invalid URL key. The "-" URL key can not be used to generate Latin URL key.
> Please use Latin letters and numbers to avoid generating URL key issues.

`AdminhtmlCategoryBeforeSavePlugin` (and `AdminhtmlProductBeforeSavePlugin`) translate the `url_key` value and then sanitise it with:

```php
strtolower((string)preg_replace('#[^0-9a-z]+#i', '-', $value))
```

That regex simply strips every character that is not `a-z0-9`. For a Latin-script target (de/fr/it) this is fine, but for Greek/Cyrillic/etc. **every** letter is removed and the key collapses to a single `-`, which Magento then rejects — the whole save blows up.

## Fix

Use the same transliteration Magento core uses to build url keys (`Magento\Catalog\Model\Category::formatUrlKey` → `FilterManager::translitUrl`). 
`translitUrl` transliterates via `Magento\Framework\Filter\Translit` (which already covers Greek and other scripts), lowercases, and normalises separators.

```php
$requestPostValue[$attributeCode] = $this->filterManager->translitUrl((string)$value);
```

`FilterManager` is injected through the constructor of both plugins.

## Result

Greek input now produces a proper Latin slug instead of an invalid key:

| input | before | after |
|---|---|---|
| `Βιολογικά βότανα και τσάι` | `-` (save error) | `biologika-botana-kai-tsai` |
| `Καλλυντικά προϊόντα` | `-` (save error) | `kalluntika-proionta` |

For a value that transliterates to nothing, `translitUrl` returns an empty string, so Magento auto-generates the key from the (translated) name — no more hard error.

## Notes

- Same bug and same fix in both the category and product save plugins.
- No behaviour change for Latin-script target languages.