### PR TITLE
Fix OpenAI translator: use Chat Completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Automatic Translation
+## [2.3.1] - 08/09/2026
+### Fixed
+- Fixed OpenAI translations returning random text instead of the translated content: the translator now uses the Chat Completions endpoint, replacing the legacy completions one
+- Fixed OpenAI errors being silently swallowed and retried instead of reported
+
 ## [2.3.0] - 26/08/2026
 ### Added
 - Support for non-Latin target languages (e.g. Greek, Cyrillic): product and category URL keys are now transliterated with Magento's URL translit filter, the same one core uses to generate URL keys

--- a/Model/Translator/OpenAI.php
+++ b/Model/Translator/OpenAI.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace MageOS\AutomaticTranslation\Model\Translator;
 
+use Exception;
 use MageOS\AutomaticTranslation\Api\TranslatorInterface;
 use MageOS\AutomaticTranslation\Helper\ModuleConfig;
 use OpenAI as OpenAITranslator;
 use OpenAI\Client as OpenAIClient;
-use Exception;
+use RuntimeException;
 
 class OpenAI implements TranslatorInterface
 {
@@ -43,24 +44,24 @@ class OpenAI implements TranslatorInterface
         $prompt = 'Translate this text, with the context that this text is used in an e-commerce store as part of a'
             . ' product description or a category description without asking any further questions or'
             . ' clarifications, giving only the answer and nothing else,'
-            . $sourceFragment . ' to ' . $targetLang . ': ' . $text;
+            . $sourceFragment . ' to ' . $targetLang . '.';
 
-        try {
-            $result = $this->translator->completions()->create([
-                'model' => $this->moduleConfig->getOpenAIModel(),
-                'prompt' => $prompt
-            ]);
+        $result = $this->translator->chat()->create([
+            'model' => $this->moduleConfig->getOpenAIModel(),
+            'messages' => [
+                ['role' => 'system', 'content' => $prompt],
+                ['role' => 'user', 'content' => $text],
+            ],
+        ])->toArray();
 
-            return trim($result['choices'][0]['text']);
-        } catch (Exception) {
-            $result = $this->translator->chat()->create([
-                'model' => $this->moduleConfig->getOpenAIModel(),
-                'messages' => [
-                    ['role' => 'user', 'content' => $prompt],
-                ],
-            ])->toArray();
-
-            return trim($result['choices'][0]['message']['content']);
+        $content = $result['choices'][0]['message']['content'];
+        if ($content === null) {
+            throw new RuntimeException((string)__(
+                'OpenAI returned an empty translation for model "%1".',
+                $this->moduleConfig->getOpenAIModel()
+            ));
         }
+
+        return trim($content);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mage-os/module-automatic-translation/issues/74.

The translator called the legacy `/v1/completions` endpoint first and only fell back to Chat Completions when an exception was thrown. With current models, the legacy endpoint can return a `200` response with unusable content, so the fallback is never triggered and that content gets saved as the translation.

* Call `chat()` directly, removing the legacy `/v1/completions` attempt.
* Pass the translation instructions as a system message and the source text as the user message.
* Throw an exception when the returned content is `null`.

**Backwards compatibility:** Completion-only models are no longer supported, as they don't support `/v1/chat/completions`.
These should be base older models with limited capabilities, so they were unlikely to produce reliable translations anyway.
